### PR TITLE
自動採番プラグインの機能で編集不可にできるため、disabledの記述を削除。

### DIFF
--- a/ankenkanri.js
+++ b/ankenkanri.js
@@ -15,9 +15,6 @@
             event.record[KOKYAKU_FIELD_CODE]["lookup"] = true;
         }
 
-        // 案件IDは自動採番なので、編集不可
-        event.record[ANKEN_FIELD_CODE].disabled = true;
-
         return event;
 
     });


### PR DESCRIPTION
自動採番プラグインの機能で編集不可にできるため、案件IDフィールドをdisabledにする記述を削除しました。
ローカルのdevelopからメインのdevelopブランチにプルリクエストを出してみます。